### PR TITLE
avoid blanket namespace import

### DIFF
--- a/lmdb-safe.cc
+++ b/lmdb-safe.cc
@@ -6,7 +6,10 @@
 #include <string.h>
 #include <map>
 
-using namespace std;
+using std::string;
+using std::runtime_error;
+using std::tuple;
+using std::weak_ptr;
 
 static string MDBError(int rc)
 {


### PR DESCRIPTION
this avoids a build error on FreeBSD. Tested in PowerDNS by @RalfvdEnden