### PR TITLE
Lots of minor changes

### DIFF
--- a/basic-example.cc
+++ b/basic-example.cc
@@ -1,5 +1,6 @@
 #include "lmdb-safe.hh"
 using namespace std;
+using namespace lmdb_safe;
 
 void checkLMDB(MDBEnv* env, MDBDbi dbi)
 {

--- a/lmdb-safe.cc
+++ b/lmdb-safe.cc
@@ -7,6 +7,7 @@
 #include <map>
 
 using namespace std;
+using namespace lmdb_safe;
 
 static string MDBError(int rc)
 {
@@ -16,17 +17,17 @@ static string MDBError(int rc)
 MDBDbi::MDBDbi(MDB_env* env, MDB_txn* txn, const string_view dbname, int flags)
 {
   // A transaction that uses this function must finish (either commit or abort) before any other transaction in the process may use this function.
-  
+
   int rc = mdb_dbi_open(txn, dbname.empty() ? 0 : &dbname[0], flags, &d_dbi);
   if(rc)
     throw std::runtime_error("Unable to open named database: " + MDBError(rc));
-  
+
   // Database names are keys in the unnamed database, and may be read but not written.
 }
 
 MDBEnv::MDBEnv(const char* fname, int flags, int mode)
 {
-  mdb_env_create(&d_env);   
+  mdb_env_create(&d_env);
   if(mdb_env_set_mapsize(d_env, 16ULL*4096*244140ULL)) // 4GB
     throw std::runtime_error("setting map size");
     /*
@@ -79,17 +80,17 @@ int MDBEnv::getROTX()
 }
 
 
-std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode)
+std::shared_ptr<MDBEnv> lmdb_safe::getMDBEnv(const char* fname, int flags, int mode)
 {
   struct Value
   {
     weak_ptr<MDBEnv> wp;
     int flags;
   };
-  
+
   static std::map<tuple<dev_t, ino_t>, Value> s_envs;
   static std::mutex mut;
-  
+
   struct stat statbuf;
   if(stat(fname, &statbuf)) {
     if(errno != ENOENT)
@@ -123,7 +124,7 @@ std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode)
 
   auto fresh = std::make_shared<MDBEnv>(fname, flags, mode);
   s_envs[key] = {fresh, flags};
-  
+
   return fresh;
 }
 
@@ -136,7 +137,7 @@ MDBDbi MDBEnv::openDB(const string_view dbname, int flags)
     This function must not be called from multiple concurrent transactions in the same process. A transaction that uses this function must finish (either commit or abort) before any other transaction in the process may use this function.
   */
   std::lock_guard<std::mutex> l(d_openmut);
-  
+
   if(!(envflags & MDB_RDONLY)) {
     auto rwt = getRWTransaction();
     MDBDbi ret = rwt->openDB(dbname, flags);
@@ -146,7 +147,7 @@ MDBDbi MDBEnv::openDB(const string_view dbname, int flags)
 
   MDBDbi ret;
   {
-    auto rwt = getROTransaction(); 
+    auto rwt = getROTransaction();
     ret = rwt->openDB(dbname, flags);
   }
   return ret;
@@ -230,7 +231,7 @@ MDB_txn *MDBROTransactionImpl::openROTransaction(MDBEnv *env, MDB_txn *parent, i
 {
   if(env->getRWTX())
     throw std::runtime_error("Duplicate RO transaction");
-  
+
   /*
     A transaction and its cursors must only be used by a single thread, and a thread may only have a single transaction at a time. If MDB_NOTLS is in use, this does not apply to read-only transactions. */
   MDB_txn *result = nullptr;

--- a/lmdb-safe.hh
+++ b/lmdb-safe.hh
@@ -1,5 +1,5 @@
 #pragma once
-#include <lmdb/lmdb.h>
+#include <lmdb.h>
 #include <iostream>
 #include <fstream>
 #include <set>

--- a/lmdb-safe.hh
+++ b/lmdb-safe.hh
@@ -70,7 +70,7 @@ using MDBRWTransaction = std::unique_ptr<MDBRWTransactionImpl>;
 class MDBEnv
 {
 public:
-  MDBEnv(const char* fname, int flags, int mode);
+  MDBEnv(string_view fname, int flags, int mode);
 
   ~MDBEnv()
   {
@@ -103,7 +103,7 @@ private:
   std::map<std::thread::id, int> d_ROtransactionsOut;
 };
 
-std::shared_ptr<MDBEnv> getMDBEnv(const char* fname, int flags, int mode);
+std::shared_ptr<MDBEnv> getMDBEnv(string_view fname, int flags, int mode);
 
 
 

--- a/lmdb-safe.hh
+++ b/lmdb-safe.hh
@@ -1,5 +1,5 @@
 #pragma once
-#include <lmdb.h>
+#include <lmdb/lmdb.h>
 #include <iostream>
 #include <fstream>
 #include <set>

--- a/lmdb-safe.hh
+++ b/lmdb-safe.hh
@@ -30,15 +30,17 @@ using std::string_view;
 /* open issues:
  *
  * - missing convenience functions (string_view, string)
- */ 
+ */
 
 /*
 The error strategy. Anything that "should never happen" turns into an exception. But things like 'duplicate entry' or 'no such key' are for you to deal with.
  */
 
 /*
-  Thread safety: we are as safe as lmdb. You can talk to MDBEnv from as many threads as you want 
+  Thread safety: we are as safe as lmdb. You can talk to MDBEnv from as many threads as you want
 */
+
+namespace lmdb_safe {
 
 /** MDBDbi is our only 'value type' object, as 1) a dbi is actually an integer
     and 2) per LMDB documentation, we never close it. */
@@ -49,13 +51,13 @@ public:
   {
     d_dbi = -1;
   }
-  explicit MDBDbi(MDB_env* env, MDB_txn* txn, string_view dbname, int flags);  
+  explicit MDBDbi(MDB_env* env, MDB_txn* txn, string_view dbname, int flags);
 
   operator const MDB_dbi&() const
   {
     return d_dbi;
   }
-  
+
   MDB_dbi d_dbi;
 };
 
@@ -78,7 +80,7 @@ public:
   }
 
   MDBDbi openDB(const string_view dbname, int flags);
-  
+
   MDBRWTransaction getRWTransaction();
   MDBROTransaction getROTransaction();
 
@@ -120,7 +122,7 @@ struct MDBOutVal
     T ret;
     if(d_mdbval.mv_size != sizeof(T))
       throw std::runtime_error("MDB data has wrong length for type");
-    
+
     memcpy(&ret, d_mdbval.mv_data, sizeof(T));
     return ret;
   }
@@ -135,7 +137,7 @@ struct MDBOutVal
     T ret;
     if(d_mdbval.mv_size != sizeof(T))
       throw std::runtime_error("MDB data has wrong length for type");
-    
+
     memcpy(&ret, d_mdbval.mv_data, sizeof(T));
     return ret;
   }
@@ -145,11 +147,11 @@ struct MDBOutVal
   {
     if(d_mdbval.mv_size != sizeof(T))
       throw std::runtime_error("MDB data has wrong length for type");
-    
+
     return reinterpret_cast<const T*>(d_mdbval.mv_data);
   }
-  
-  
+
+
   MDB_val d_mdbval;
 };
 
@@ -174,7 +176,7 @@ public:
   template <class T,
             typename std::enable_if<std::is_arithmetic<T>::value,
                                     T>::type* = nullptr>
-  MDBInVal(T i) 
+  MDBInVal(T i)
   {
     memcpy(&d_memory[0], &i, sizeof(i));
     d_mdbval.mv_size = sizeof(T);
@@ -186,20 +188,20 @@ public:
     d_mdbval.mv_size = strlen(s);
     d_mdbval.mv_data = (void*)s;
   }
-  
-  MDBInVal(const string_view& v) 
+
+  MDBInVal(const string_view& v)
   {
     d_mdbval.mv_size = v.size();
     d_mdbval.mv_data = (void*)&v[0];
   }
 
-  MDBInVal(const std::string& v) 
+  MDBInVal(const std::string& v)
   {
     d_mdbval.mv_size = v.size();
     d_mdbval.mv_data = (void*)&v[0];
   }
 
-  
+
   template<typename T>
   static MDBInVal fromStruct(const T& t)
   {
@@ -208,7 +210,7 @@ public:
     ret.d_mdbval.mv_data = (void*)&t;
     return ret;
   }
-  
+
   operator MDB_val&()
   {
     return d_mdbval;
@@ -265,7 +267,7 @@ public:
                      const_cast<MDB_val*>(&val.d_mdbval));
     if(rc && rc != MDB_NOTFOUND)
       throw std::runtime_error("getting data: " + std::string(mdb_strerror(rc)));
-    
+
     return rc;
   }
 
@@ -278,7 +280,7 @@ public:
     return rc;
   }
 
-  
+
   // this is something you can do, readonly
   MDBDbi openDB(string_view dbname, int flags)
   {
@@ -287,7 +289,7 @@ public:
 
   MDBROCursor getCursor(const MDBDbi&);
   MDBROCursor getROCursor(const MDBDbi&);
-    
+
   operator MDB_txn*()
   {
     return d_txn;
@@ -303,8 +305,8 @@ public:
   }
 };
 
-/* 
-   A cursor in a read-only transaction must be closed explicitly, before or after its transaction ends. It can be reused with mdb_cursor_renew() before finally closing it. 
+/*
+   A cursor in a read-only transaction must be closed explicitly, before or after its transaction ends. It can be reused with mdb_cursor_renew() before finally closing it.
 
    "If the parent transaction commits, the cursor must not be used again."
 */
@@ -394,7 +396,7 @@ public:
        throw std::runtime_error("Unable to find from cursor: " + std::string(mdb_strerror(rc)));
     return rc;
   }
-  
+
   int lower_bound(const MDBInVal& in, MDBOutVal& key, MDBOutVal& data)
   {
     key.d_mdbval = in.d_mdbval;
@@ -405,7 +407,7 @@ public:
     return rc;
   }
 
-  
+
   int nextprev(MDBOutVal& key, MDBOutVal& data, MDB_cursor_op op)
   {
     int rc = mdb_cursor_get(d_cursor, const_cast<MDB_val*>(&key.d_mdbval), &data.d_mdbval, op);
@@ -514,12 +516,12 @@ public:
   MDBRWTransactionImpl &operator=(MDBRWTransactionImpl&& rhs) = delete;
 
   ~MDBRWTransactionImpl() override;
-  
+
   void commit() override;
   void abort() override;
 
   void clear(MDB_dbi dbi);
-  
+
   void put(MDB_dbi dbi, const MDBInVal& key, const MDBInVal& val, int flags=0)
   {
     if(!d_txn)
@@ -550,7 +552,7 @@ public:
     return rc;
   }
 
- 
+
   int get(MDBDbi& dbi, const MDBInVal& key, MDBOutVal& val)
   {
     if(!d_txn)
@@ -571,7 +573,7 @@ public:
       val = out.get<string_view>();
     return rc;
   }
-  
+
   MDBDbi openDB(string_view dbname, int flags)
   {
     return MDBDbi(environment().d_env, d_txn, dbname, flags);
@@ -584,7 +586,7 @@ public:
   MDBROTransaction getROTransaction();
 };
 
-/* "A cursor in a write-transaction can be closed before its transaction ends, and will otherwise be closed when its transaction ends" 
+/* "A cursor in a write-transaction can be closed before its transaction ends, and will otherwise be closed when its transaction ends"
    This is a problem for us since it may means we are closing the cursor twice, which is bad
 */
 class MDBRWCursor : public MDBGenCursor<MDBRWTransactionImpl, MDBRWCursor>
@@ -607,7 +609,7 @@ public:
       throw std::runtime_error("mdb_cursor_put: " + std::string(mdb_strerror(rc)));
   }
 
-  
+
   int put(const MDBOutVal& key, const MDBOutVal& data, int flags=0)
   {
     // XXX check errors
@@ -622,4 +624,4 @@ public:
   }
 
 };
-
+}

--- a/lmdb-typed.cc
+++ b/lmdb-typed.cc
@@ -1,6 +1,6 @@
 #include "lmdb-typed.hh"
-using namespace lmdb_safe;
-unsigned int MDBGetMaxID(MDBRWTransaction& txn, MDBDbi& dbi)
+
+unsigned int lmdb_safe::MDBGetMaxID(lmdb_safe::MDBRWTransaction& txn, lmdb_safe::MDBDbi& dbi)
 {
   auto cursor = txn->getRWCursor(dbi);
   MDBOutVal maxidval, maxcontent;

--- a/lmdb-typed.cc
+++ b/lmdb-typed.cc
@@ -1,5 +1,5 @@
 #include "lmdb-typed.hh"
-
+using namespace lmdb_safe;
 unsigned int MDBGetMaxID(MDBRWTransaction& txn, MDBDbi& dbi)
 {
   auto cursor = txn->getRWCursor(dbi);

--- a/lmdb-typed.hh
+++ b/lmdb-typed.hh
@@ -81,14 +81,14 @@ void serFromString(const string_view& str, T& ret)
 template <class T, class Enable = void>
 inline std::string keyConv(const T& t);
 
-template <class T, typename std::enable_if<std::is_arithmetic<T>::value,T>::type* = nullptr>
+template <class T, typename std::enable_if_t<std::is_arithmetic<T>::value,int> = 0>
 inline std::string keyConv(const T& t)
 {
   return std::string((char*)&t, sizeof(t));
 }
 
 // this is how to override specific types.. it is ugly
-template<class T, typename std::enable_if<std::is_same<T, std::string>::value,T>::type* = nullptr>
+template<typename T, typename std::enable_if_t<std::is_convertible_v<T, std::string>,int> = 0>
 inline std::string keyConv(const T& t)
 {
   return t;

--- a/lmdb-typed.hh
+++ b/lmdb-typed.hh
@@ -79,18 +79,21 @@ void serFromString(const string_view& str, T& ret)
   std::string serToString(const T &t);
 #endif // NO_BOOST_SERIALIZATION
 
-template <class T, class Enable = void>
-inline std::string keyConv(const T& t);
+template <class T>
+std::string keyConv(const T& t)
+{
+    return serToString<T>(t);
+}
 
 template <class T, typename std::enable_if_t<std::is_arithmetic<T>::value,int> = 0>
-inline std::string keyConv(const T& t)
+std::string keyConv(const T& t)
 {
   return std::string((char*)&t, sizeof(t));
 }
 
 // this is how to override specific types.. it is ugly
 template<typename T, typename std::enable_if_t<std::is_convertible_v<T, std::string>,int> = 0>
-inline std::string keyConv(const T& t)
+std::string keyConv(const T& t)
 {
   return t;
 }

--- a/lmdb-typed.hh
+++ b/lmdb-typed.hh
@@ -72,10 +72,13 @@ void serFromString(const string_view& str, T& ret)
   */
 }
 #else
-
+  template <typename T>
+  void serFromString(const string_view &str, T &ret);
+  template <typename T> 
+  std::string serToString(const T &t);
 #endif // NO_BOOST_SERIALIZATION
 
-template <class T, class Enable>
+template <class T, class Enable = void>
 inline std::string keyConv(const T& t);
 
 template <class T, typename std::enable_if<std::is_arithmetic<T>::value,T>::type* = nullptr>

--- a/lmdb-typed.hh
+++ b/lmdb-typed.hh
@@ -14,7 +14,7 @@
 // using std::endl;
 
 
-/* 
+/*
    Open issues:
 
    Everything should go into a namespace
@@ -28,9 +28,10 @@
      make it more value "like" with unique_ptr
 */
 
+namespace lmdb_safe {
 
 /** Return the highest ID used in a database. Returns 0 for an empty DB.
-    This makes us start everything at ID=1, which might make it possible to 
+    This makes us start everything at ID=1, which might make it possible to
     treat id 0 as special
 */
 unsigned int MDBGetMaxID(MDBRWTransaction& txn, MDBDbi& dbi);
@@ -45,7 +46,7 @@ std::string serToString(const T& t)
   boost::iostreams::back_insert_device<std::string> inserter(serial_str);
   boost::iostreams::stream<boost::iostreams::back_insert_device<std::string> > s(inserter);
   boost::archive::binary_oarchive oa(s, boost::archive::no_header | boost::archive::no_codecvt);
-  
+
   oa << t;
   return serial_str;
 }
@@ -77,7 +78,7 @@ inline std::string keyConv(const T& t)
   return std::string((char*)&t, sizeof(t));
 }
 
-// this is how to override specific types.. it is ugly 
+// this is how to override specific types.. it is ugly
 template<class T, typename std::enable_if<std::is_same<T, std::string>::value,T>::type* = nullptr>
 inline std::string keyConv(const T& t)
 {
@@ -85,7 +86,7 @@ inline std::string keyConv(const T& t)
 }
 
 
-/** This is a struct that implements index operations, but 
+/** This is a struct that implements index operations, but
     only the operations that are broadcast to all indexes.
     Specifically, to deal with databases with less than the maximum
     number of interfaces, this only includes calls that should be
@@ -130,7 +131,7 @@ struct index_on : LMDBIndexOps<Class, Type, index_on<Class, Type, PtrToMember>>
   {
     return c.*PtrToMember;
   }
-  
+
   typedef Type type;
 };
 
@@ -146,7 +147,7 @@ struct index_on_function : LMDBIndexOps<Class, Type, index_on_function<Class, Ty
     return f(c);
   }
 
-  typedef Type type;           
+  typedef Type type;
 };
 
 /** nop index, so we can fill our N indexes, even if you don't use them all */
@@ -158,10 +159,10 @@ struct nullindex_t
   template<typename Class>
   void del(MDBRWTransaction& txn, const Class& t, uint32_t id)
   {}
-  
+
   void openDB(std::shared_ptr<MDBEnv>& env, string_view str, int flags)
   {
-    
+
   }
   typedef uint32_t type; // dummy
 };
@@ -188,9 +189,9 @@ public:
 #undef openMacro
   }
 
-  
+
   // we get a lot of our smarts from this tuple, it enables get<0> etc
-  typedef std::tuple<I1, I2, I3, I4> tuple_t; 
+  typedef std::tuple<I1, I2, I3, I4> tuple_t;
   tuple_t d_tuple;
 
   // We support readonly and rw transactions. Here we put the Readonly operations
@@ -224,7 +225,7 @@ public:
       MDBOutVal data;
       if((*d_parent.d_txn)->get(d_parent.d_parent->d_main, id, data))
         return false;
-      
+
       serFromString(data.get<std::string>(), t);
       return true;
     }
@@ -277,7 +278,7 @@ public:
         if(d_end)
           return;
         d_prefix.clear();
-        
+
         if(d_cursor.get(d_key, d_id,  MDB_GET_CURRENT)) {
           d_end = true;
           return;
@@ -297,7 +298,7 @@ public:
         d_cursor(std::move(cursor)),
         d_on_index(true), // is this an iterator on main database or on index?
         d_one_key(false),
-        d_prefix(prefix),  
+        d_prefix(prefix),
         d_end(false)
       {
         if(d_end)
@@ -317,28 +318,28 @@ public:
           serFromString(d_id.get<std::string>(), d_t);
       }
 
-      
+
       std::function<bool(const MDBOutVal&)> filter;
       void del()
       {
         d_cursor.del();
       }
-      
+
       bool operator!=(const eiter_t& rhs) const
       {
         return !d_end;
       }
-      
+
       bool operator==(const eiter_t& rhs) const
       {
         return d_end;
       }
-      
+
       const T& operator*()
       {
         return d_t;
       }
-      
+
       const T* operator->()
       {
         return &d_t;
@@ -366,13 +367,13 @@ public:
               throw std::runtime_error("Missing id field");
             if(filter && !filter(data))
               goto next;
-            
+
             serFromString(data.get<std::string>(), d_t);
           }
           else {
             if(filter && !filter(data))
               goto next;
-                        
+
             serFromString(d_id.get<std::string>(), d_t);
           }
         }
@@ -401,8 +402,8 @@ public:
       {
         return d_key;
       }
-      
-      
+
+
       // transaction we are part of
       Parent* d_parent;
       typename Parent::cursor_t d_cursor;
@@ -420,9 +421,9 @@ public:
     iter_t genbegin(MDB_cursor_op op)
     {
       typename Parent::cursor_t cursor = (*d_parent.d_txn)->getCursor(std::get<N>(d_parent.d_parent->d_tuple).d_idx);
-      
+
       MDBOutVal out, id;
-      
+
       if(cursor.get(out, id,  op)) {
                                              // on_index, one_key, end
         return iter_t{&d_parent, std::move(cursor), true, false, true};
@@ -446,11 +447,11 @@ public:
     iter_t begin()
     {
       typename Parent::cursor_t cursor = (*d_parent.d_txn)->getCursor(d_parent.d_parent->d_main);
-      
+
       MDBOutVal out, id;
-      
+
       if(cursor.get(out, id,  MDB_FIRST)) {
-                                              // on_index, one_key, end        
+                                              // on_index, one_key, end
         return iter_t{&d_parent, std::move(cursor), false, false, true};
       }
 
@@ -472,9 +473,9 @@ public:
       MDBInVal in(keystr);
       MDBOutVal out, id;
       out.d_mdbval = in.d_mdbval;
-      
+
       if(cursor.get(out, id,  op)) {
-                                              // on_index, one_key, end        
+                                              // on_index, one_key, end
         return iter_t{&d_parent, std::move(cursor), true, false, true};
       }
 
@@ -504,9 +505,9 @@ public:
       MDBInVal in(keyString);
       MDBOutVal out, id;
       out.d_mdbval = in.d_mdbval;
-      
+
       if(cursor.get(out, id,  MDB_SET)) {
-                                              // on_index, one_key, end        
+                                              // on_index, one_key, end
         return {iter_t{&d_parent, std::move(cursor), true, true, true}, eiter_t()};
       }
 
@@ -523,34 +524,34 @@ public:
       MDBInVal in(keyString);
       MDBOutVal out, id;
       out.d_mdbval = in.d_mdbval;
-      
+
       if(cursor.get(out, id,  MDB_SET_RANGE)) {
-                                              // on_index, one_key, end        
+                                              // on_index, one_key, end
         return {iter_t{&d_parent, std::move(cursor), true, true, true}, eiter_t()};
       }
 
       return {iter_t(&d_parent, std::move(cursor), keyString), eiter_t()};
     };
 
-    
+
     Parent& d_parent;
   };
-  
+
   class ROTransaction : public ReadonlyOperations<ROTransaction>
   {
   public:
-    explicit ROTransaction(TypedDBI* parent) : ReadonlyOperations<ROTransaction>(*this), d_parent(parent), d_txn(std::make_shared<MDBROTransaction>(d_parent->d_env->getROTransaction())) 
+    explicit ROTransaction(TypedDBI* parent) : ReadonlyOperations<ROTransaction>(*this), d_parent(parent), d_txn(std::make_shared<MDBROTransaction>(d_parent->d_env->getROTransaction()))
     {
     }
 
-    explicit ROTransaction(TypedDBI* parent, std::shared_ptr<MDBROTransaction> txn) : ReadonlyOperations<ROTransaction>(*this), d_parent(parent), d_txn(txn) 
+    explicit ROTransaction(TypedDBI* parent, std::shared_ptr<MDBROTransaction> txn) : ReadonlyOperations<ROTransaction>(*this), d_parent(parent), d_txn(txn)
     {
     }
 
-    
+
     ROTransaction(ROTransaction&& rhs) :
       ReadonlyOperations<ROTransaction>(*this), d_parent(rhs.d_parent),d_txn(std::move(rhs.d_txn))
-      
+
     {
       rhs.d_parent = 0;
     }
@@ -559,14 +560,14 @@ public:
     {
       return d_txn;
     }
-    
+
     typedef MDBROCursor cursor_t;
 
     TypedDBI* d_parent;
-    std::shared_ptr<MDBROTransaction> d_txn;    
-  };    
+    std::shared_ptr<MDBROTransaction> d_txn;
+  };
 
-  
+
   class RWTransaction :  public ReadonlyOperations<RWTransaction>
   {
   public:
@@ -579,7 +580,7 @@ public:
     {
     }
 
-    
+
     RWTransaction(RWTransaction&& rhs) :
       ReadonlyOperations<RWTransaction>(*this),
       d_parent(rhs.d_parent), d_txn(std::move(rhs.d_txn))
@@ -611,10 +612,10 @@ public:
     void modify(uint32_t id, std::function<void(T&)> func)
     {
       T t;
-      if(!this->get(id, t)) 
+      if(!this->get(id, t))
         throw std::runtime_error("Could not modify id "+std::to_string(id));
       func(t);
-      
+
       del(id);  // this is the lazy way. We could test for changed index fields
       put(t, id);
     }
@@ -623,9 +624,9 @@ public:
     void del(uint32_t id)
     {
       T t;
-      if(!this->get(id, t)) 
+      if(!this->get(id, t))
         return;
-      
+
       (*d_txn)->del(d_parent->d_main, id);
       clearIndex(id, t);
     }
@@ -664,7 +665,7 @@ public:
       return d_txn;
     }
 
-    
+
   private:
     // clear this ID from all indexes
     void clearIndex(uint32_t id, const T& t)
@@ -674,7 +675,7 @@ public:
       clearMacro(1);
       clearMacro(2);
       clearMacro(3);
-#undef clearMacro      
+#undef clearMacro
     }
 
   public:
@@ -710,14 +711,14 @@ public:
   {
     return d_env;
   }
-  
+
 private:
   std::shared_ptr<MDBEnv> d_env;
   MDBDbi d_main;
   std::string d_name;
 };
 
-
+}
 
 
 

--- a/lmdb-typed.hh
+++ b/lmdb-typed.hh
@@ -270,16 +270,26 @@ public:
       return count;
     }
 
+    struct iter_t;
+
     //! End iderator type
-    struct eiter_t
-    {};
+    struct eiter_t {
+        bool operator!=(const iter_t &) const 
+        { 
+            return true; 
+        }
+        bool operator==(const iter_t &) const 
+        { 
+            return false; 
+        }
+    };
 
     // can be on main, or on an index
     // when on main, return data directly
     // when on index, indirect
     // we can be limited to one key, or iterate over entire database
     // iter requires you to put the cursor in the right place first!
-    struct iter_t
+    struct iter_t : std::iterator<std::input_iterator_tag, T>
     {
       explicit iter_t(Parent* parent, typename Parent::cursor_t&& cursor, bool on_index, bool one_key, bool end=false) :
         d_parent(parent),
@@ -348,7 +358,17 @@ public:
         return d_end;
       }
 
-      const T& operator*()
+      bool operator!=(const iter_t& rhs) const
+      {
+        return rhs.d_t != d_t;
+      }
+
+      bool operator==(const iter_t& rhs) const
+      {
+         return rhs.d_t == d_t;
+      }
+      
+      const T& operator*() const
       {
         return d_t;
       }
@@ -418,13 +438,13 @@ public:
 
 
       // transaction we are part of
-      Parent* d_parent;
+      Parent* d_parent = nullptr;
       typename Parent::cursor_t d_cursor;
 
       // gcc complains if I don't zero-init these, which is worrying XXX
       MDBOutVal d_key{{0,0}}, d_data{{0,0}}, d_id{{0,0}};
-      bool d_on_index;
-      bool d_one_key;
+      bool d_on_index{false};
+      bool d_one_key{false};
       std::string d_prefix;
       bool d_end{false};
       T d_t;

--- a/lmdb-typed.hh
+++ b/lmdb-typed.hh
@@ -1,6 +1,9 @@
 #pragma once
 #include <iostream>
 #include "lmdb-safe.hh"
+#include <sstream>
+
+#ifndef _NO_BOOST_SERIALIZATION
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/serialization/vector.hpp>
@@ -9,7 +12,7 @@
 #include <boost/iostreams/stream.hpp>
 #include <boost/iostreams/stream_buffer.hpp>
 #include <boost/iostreams/device/back_inserter.hpp>
-#include <sstream>
+#endif // _NO_BOOST_SERIALIZATION
 // using std::cout;
 // using std::endl;
 
@@ -39,6 +42,7 @@ unsigned int MDBGetMaxID(MDBRWTransaction& txn, MDBDbi& dbi);
 /** This is our serialization interface.
     You can define your own serToString for your type if you know better
 */
+#ifndef _NO_BOOST_SERIALIZATION
 template<typename T>
 std::string serToString(const T& t)
 {
@@ -67,7 +71,9 @@ void serFromString(const string_view& str, T& ret)
   oi >> ret;
   */
 }
+#else
 
+#endif // _NO_BOOST_SERIALIZATION
 
 template <class T, class Enable>
 inline std::string keyConv(const T& t);

--- a/lmdb-typed.hh
+++ b/lmdb-typed.hh
@@ -3,7 +3,7 @@
 #include "lmdb-safe.hh"
 #include <sstream>
 
-#ifndef _NO_BOOST_SERIALIZATION
+#ifndef NO_BOOST_SERIALIZATION
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/serialization/vector.hpp>
@@ -12,7 +12,7 @@
 #include <boost/iostreams/stream.hpp>
 #include <boost/iostreams/stream_buffer.hpp>
 #include <boost/iostreams/device/back_inserter.hpp>
-#endif // _NO_BOOST_SERIALIZATION
+#endif // NO_BOOST_SERIALIZATION
 // using std::cout;
 // using std::endl;
 
@@ -42,7 +42,7 @@ unsigned int MDBGetMaxID(MDBRWTransaction& txn, MDBDbi& dbi);
 /** This is our serialization interface.
     You can define your own serToString for your type if you know better
 */
-#ifndef _NO_BOOST_SERIALIZATION
+#ifndef NO_BOOST_SERIALIZATION
 template<typename T>
 std::string serToString(const T& t)
 {
@@ -73,7 +73,7 @@ void serFromString(const string_view& str, T& ret)
 }
 #else
 
-#endif // _NO_BOOST_SERIALIZATION
+#endif // NO_BOOST_SERIALIZATION
 
 template <class T, class Enable>
 inline std::string keyConv(const T& t);

--- a/lmdb-typed.hh
+++ b/lmdb-typed.hh
@@ -2,6 +2,7 @@
 #include <iostream>
 #include "lmdb-safe.hh"
 #include <sstream>
+#include <functional>
 
 #ifndef NO_BOOST_SERIALIZATION
 #include <boost/archive/binary_oarchive.hpp>

--- a/lmdb-various.cc
+++ b/lmdb-various.cc
@@ -6,7 +6,7 @@
 #include <thread>
 #include <vector>
 using namespace std;
-
+using namespace lmdb_safe;
 static void closeTest()
 {
   auto env = getMDBEnv("./database", 0, 0600);

--- a/lmdb-view.cc
+++ b/lmdb-view.cc
@@ -2,6 +2,7 @@
 #include <iostream>
 
 using namespace std;
+using namespace lmdb_safe;
 
 void countDB(MDBEnv& env, MDBROTransaction& txn, const std::string& dbname)
 {

--- a/multi-example.cc
+++ b/multi-example.cc
@@ -1,5 +1,6 @@
 #include "lmdb-safe.hh"
 using namespace std;
+using namespace lmdb_safe;
 
 #include <unistd.h>
 

--- a/rel-example.cc
+++ b/rel-example.cc
@@ -3,6 +3,7 @@
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/binary_iarchive.hpp>
 using namespace std;
+using namespace lmdb_safe;
 
 struct Record
 {

--- a/resize-example.cc
+++ b/resize-example.cc
@@ -1,6 +1,7 @@
 #include "lmdb-safe.hh"
 #include <string.h>
 using namespace std;
+using namespace lmdb_safe;
 
 int main(int argc, char** argv)
 {

--- a/scale-example.cc
+++ b/scale-example.cc
@@ -1,5 +1,6 @@
 #include "lmdb-safe.hh"
 using namespace std;
+using namespace lmdb_safe;
 
 struct MDBVal
 {

--- a/test-basic.cc
+++ b/test-basic.cc
@@ -5,6 +5,7 @@
 #include "lmdb-safe.hh"
 
 using namespace std;
+using namespace lmdb_safe;
 
 TEST_CASE("Most basic tests", "[mostbasic]") {
   unlink("./tests");

--- a/typed-example.cc
+++ b/typed-example.cc
@@ -3,6 +3,7 @@
 
 #include <string>
 using namespace std;
+using namespace lmdb_safe;
 
 struct DNSResourceRecord
 {

--- a/typed-test.cc
+++ b/typed-test.cc
@@ -4,6 +4,7 @@
 #include "lmdb-typed.hh"
 
 using namespace std;
+using namespace lmdb_safe;
 
 struct Member
 {


### PR DESCRIPTION
First of all a big thanks to you for this library.  I was able to remove about 1k lines of questionable code.  I did make a few changes though to adapt it to my codebase:

1. Move the lmdb safe classes into their own namespace.  
2. Allow boost serialization to be optional.  I use cbor from jsoncons, so I wanted to keep using that.
3. Changed `keyConv` to use `setToString` for anything that was not a number or string.  (I needed this to index on a uuid data type)
4. Made iterator derive from `std::iterator` as a `std::input_iterator_tag`.  Even though it is really bidirectional there are some features that it doesn't support to tag it as a bidirectional.  Since I only did this so that I could use it with range-v3 I only needed forward.
5. Added needed `--` and `!=` operators to `iter_t` and `eiter_t` to satisfy std::range requirements. 

I attempted to keep the changes to a minimum, but my text editor was set to automatically trim trailing whitespace.  I can back that out if you need me to.  I await your feedback.  Thanks!