### PR TITLE
use std::string_view whenever possible

### DIFF
--- a/lmdb-safe.hh
+++ b/lmdb-safe.hh
@@ -13,7 +13,9 @@
 #include <algorithm>
 
 // apple compiler somehow has string_view even in c++11!
-#if __cplusplus < 201703L && !defined(__APPLE__)
+#ifdef __cpp_lib_string_view
+using std::string_view;
+#else
 #include <boost/version.hpp>
 #if BOOST_VERSION > 105400
 #include <boost/utility/string_view.hpp>
@@ -22,8 +24,6 @@ using boost::string_view;
 #include <boost/utility/string_ref.hpp>
 using string_view = boost::string_ref;
 #endif
-#else // C++17
-using std::string_view;
 #endif
 
 


### PR DESCRIPTION
std::string_view is available with libcxx, even in C++11 mode. Use the proper macro to check it.