### PR TITLE
avoid std::move() on temporary at -werror

### DIFF
--- a/lmdb-safe.cc
+++ b/lmdb-safe.cc
@@ -333,7 +333,7 @@ MDBRWTransaction MDBRWTransactionImpl::getRWTransaction()
 
 MDBROTransaction MDBRWTransactionImpl::getROTransaction()
 {
-  return std::move(getRWTransaction());
+  return getRWTransaction();
 }
 
 MDBROTransaction MDBEnv::getROTransaction()


### PR DESCRIPTION
/home/jenkins-build/build/workspace/ceph-pull-requests/src/rgw/driver/posix/lmdb-safe/lmdb-safe.cc:336:10: error: moving a temporary object prevents copy elision [-Werror,-Wpessimizing-move]
  return std::move(getRWTransaction());
         ^
/home/jenkins-build/build/workspace/ceph-pull-requests/src/rgw/driver/posix/lmdb-safe/lmdb-safe.cc:336:10: note: remove std::move call here
  return std::move(getRWTransaction());
         ^~~~~~~~~~                  ~
1 error generated.